### PR TITLE
Dependency on mockito-core instead of mockito-all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1369,7 +1369,7 @@
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
+        <artifactId>mockito-core</artifactId>
         <version>1.8.5</version>
         <scope>test</scope>
       </dependency>


### PR DESCRIPTION
Fixing conflicts between mockito-all 1.8.5 and hamcrest 1.2
