### PR TITLE
spring-data-jpa-1.1.0. Switch the latest version of Spring Data (1.1.0) ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -909,45 +909,7 @@
       <dependency>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-jpa</artifactId>
-        <version>1.0.3.RELEASE</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.aop</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.asm</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.beans</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.context</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.expression</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.jdbc</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.orm</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.springframework</groupId>
-            <artifactId>org.springframework.transaction</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>1.1.0.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>javax.transaction</groupId>
@@ -1828,7 +1790,7 @@
   </profiles>
 
   <properties>
-    <aspectj.version>1.6.11</aspectj.version>
+    <aspectj.version>1.6.12</aspectj.version>
     <bouncycastle.version>1.46</bouncycastle.version>
     <jersey.version>1.11.1</jersey.version>
     <jackson.version>1.9.7</jackson.version>


### PR DESCRIPTION
...and of AspectJ (1.6.12)

Don't forget to merge also the branch spring-data-jpa-1.1.0 of the Silverpeas-Core and Silverpeas-Component projects.
