### PR TITLE
Bug #3404. Update of the dependency on metadata-extractor and on tika-parsers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,7 @@
       <dependency>
         <groupId>org.apache.tika</groupId>
         <artifactId>tika-parsers</artifactId>
+        <classifier>silverpeas</classifier>
         <version>${tika.version}</version>
         <exclusions>
           <exclusion>
@@ -1168,7 +1169,7 @@
       <dependency>
         <groupId>com.drewnoakes</groupId>
         <artifactId>metadata-extractor</artifactId>        
-        <version>2.5.0-RC3</version>
+        <version>2.6.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sanselan</groupId>


### PR DESCRIPTION
Switch metadata-extractor to the last version (2.6.2) and set the dependency on tika-parsers with the one patched by us and available in our nexus under the classifier silverpeas. The tika-parsers is patched to be compatible with the API change of metadata-extractor version >= 2.5

WARNING: don't forget to merge also the branch bug-3404 in the project Silverpeas-Core.
